### PR TITLE
Replaced harsh row (id) removal with a soft feature remover

### DIFF
--- a/R/reduce_dims.R
+++ b/R/reduce_dims.R
@@ -12,6 +12,7 @@
 #' @param norm_method \code{character} denoting the rescaling/normalising method to apply. Can be one of \code{"z-score"}, \code{"Sigmoid"}, \code{"RobustSigmoid"}, or \code{"MinMax"}. Defaults to \code{"z-score"}
 #' @param unit_int \code{Boolean} whether to rescale into unit interval \code{[0,1]} after applying normalisation method. Defaults to \code{FALSE}
 #' @param low_dim_method \code{character} specifying the low dimensional embedding method to use. Defaults to \code{"PCA"}
+#' @param na_removal \code{character} defines the way to deal with NAs produced during feature calculation. \code{"feature"} removes all features that produced any NAs in any sample, keeping the number of samples the same. \code{"sample"} omits all samples that produced at least one NA. Defaults to \code{"feature"}
 #' @param perplexity \code{integer} denoting the perplexity hyperparameter to use if \code{low_dim_method} is \code{"t-SNE"}. Defaults to \code{10}
 #' @param seed \code{integer} to fix R's random number generator to ensure reproducibility. Defaults to \code{123}
 #' @param ... arguments to be passed to either \code{stats::prcomp} or \code{Rtsne::Rtsne} depending on whether \code{"low_dim_method"} is \code{"PCA"} or \code{"t-SNE"}
@@ -21,12 +22,13 @@
 #' 
 
 reduce_dims <- function(data, norm_method = c("z-score", "Sigmoid", "RobustSigmoid", "MinMax"), unit_int = FALSE,
-                        low_dim_method = c("PCA", "t-SNE"), perplexity = 10, seed = 123, ...){
+                        low_dim_method = c("PCA", "t-SNE"), na_removal = c("feature","sample"), perplexity = 10, seed = 123, ...){
 
   stopifnot(inherits(data, "feature_calculations") == TRUE)
   norm_method <- match.arg(norm_method)
   low_dim_method <- match.arg(low_dim_method)
-
+  na_removal <- match.arg(na_removal)
+    
   #------------- Normalise data -------------------
 
   normed <- data[[1]] %>%
@@ -42,12 +44,30 @@ reduce_dims <- function(data, norm_method = c("z-score", "Sigmoid", "RobustSigmo
   #------------- Perform low dim ----------------------
   
   # Produce matrix
-  
+    
   wide_data <- normed %>%
     tidyr::pivot_wider(id_cols = "id", names_from = "names", values_from = "values") %>%
-    tibble::column_to_rownames(var = "id") %>%
-    dplyr::select(where(~!any(is.na(.x))))
-  
+      tibble::column_to_rownames(var = "id") %>%
+      ##tidyr::drop_na()
+      {if (na_removal == "feature") dplyr::select(., where(~!any(is.na(.)))) else . } %>%
+      {if (na_removal == "sample") tidyr::drop_na(.) else .}
+
+  # Report omitted features/samples
+
+    n_features <- length(unique(normed$names))
+    n_samples <- length(unique(normed$id))
+
+    n_features_after <- ncol(wide_data)
+    n_samples_after <- nrow(wide_data)
+
+    n_features_omitted <- n_features - n_features_after
+    n_samples_omitted <- n_samples - n_samples_after
+
+    if (n_features_omitted > 0) {message(paste(n_features_omitted, "features omitted due to NAs", sep = " "))}
+
+    if (n_samples_omitted > 0) {message(paste(n_samples_omitted, "samples omitted due to NAs", sep = " "))}
+    
+    
   if(low_dim_method == "PCA"){
     
     # PCA calculation

--- a/R/reduce_dims.R
+++ b/R/reduce_dims.R
@@ -46,7 +46,7 @@ reduce_dims <- function(data, norm_method = c("z-score", "Sigmoid", "RobustSigmo
   wide_data <- normed %>%
     tidyr::pivot_wider(id_cols = "id", names_from = "names", values_from = "values") %>%
     tibble::column_to_rownames(var = "id") %>%
-    tidyr::drop_na()
+    dplyr::select(where(~!any(is.na(.x))))
   
   if(low_dim_method == "PCA"){
     


### PR DESCRIPTION
I noticed when running reduce_dims on a  feature matrix that contains NAs, that I seem to always lose many of the samples (IDs). This was caused by tidyr::drop_na, which removes all rows that contain *any* NA. This means, that in a situation where there is a calculated feature that produces some NAs, drop_na will remove *all* the rows where this feature is NA, even though they might have correct values in the other features.

The drop_na call was probably introduced to avoid NAs for PCA and tSNE (since they don't like them). I suggest replacing the drop_na call with one that removes columns (features) that contain some NAs.

This might not be the best choice since it means that if a feature produces an NA in a single sample, the feature will be kicked out. But I believe, since there is potential to calculate thousands of features, dropping a few here and there are better than losing samples.